### PR TITLE
Support JSXElement. (no parse)

### DIFF
--- a/src/Util/ASTUtil.js
+++ b/src/Util/ASTUtil.js
@@ -1,7 +1,8 @@
 import estraverse from 'estraverse';
 
 let ESTRAVERSE_KEYS = {
-  Super: []
+  Super: [],
+  JSXElement: []
 };
 
 /**


### PR DESCRIPTION
Currently, an error occurs when I target files including jsx syntax like below.

```js
import React from 'react';
 
class App extends React.Component {
  render() {
    return <div>Hello</div>;
  }
}
```

* error trace

```
Error: Unknown node type JSXElement.
    at Controller.traverse (/Users/koba04/project/node_modules/esdoc/node_modules/estraverse/estraverse.js:515:31)
    at Object.traverse (/Users/koba04/project/node_modules/esdoc/node_modules/estraverse/estraverse.js:707:27)
    at Function.findPathInImportDeclaration (/Users/koba04/project/node_modules/esdoc/out/src/Util/ASTUtil.js:60:31)
    at ClassDoc._resolveLongname (/Users/koba04/project/node_modules/esdoc/out/src/Doc/AbstractDoc.js:943:51)
    at ClassDoc._extends (/Users/koba04/project/node_modules/esdoc/out/src/Doc/ClassDoc.js:137:29)
    at ClassDoc._apply (/Users/koba04/project/node_modules/esdoc/out/src/Doc/ClassDoc.js:53:23)
    at ClassDoc.AbstractDoc (/Users/koba04/project/node_modules/esdoc/out/src/Doc/AbstractDoc.js:54:10)
    at new ClassDoc (/Users/koba04/project/node_modules/esdoc/out/src/Doc/ClassDoc.js:36:20)
    at DocFactory._createDoc (/Users/koba04/project/node_modules/esdoc/out/src/Factory/DocFactory.js:320:14)
    at DocFactory._traverseComments (/Users/koba04/project/node_modules/esdoc/out/src/Factory/DocFactory.js:250:24)
```

This pull request is for fixing it.
This doesn't include parsing JSX tree.