### PR TITLE
Fix a link to Home. 

### DIFF
--- a/src/Publisher/Builder/template/layout.html
+++ b/src/Publisher/Builder/template/layout.html
@@ -13,7 +13,7 @@
 <body class="layout-container">
 
 <header>
-  <a href="./">Home</a>
+  <a href="index.html">Home</a>
   <a href="identifiers.html">Identifier</a>
   <a href="source.html">Source</a>
   <a href="test.html" data-ice="testLink">Test</a>


### PR DESCRIPTION
when I open an esdoc page by a local file path, `/` shows file index page instead of Home.
This pull request specifies index.html explicitly.