### PR TITLE
Use good example for not nullable types

### DIFF
--- a/doc/src/documents/tags.html.md
+++ b/doc/src/documents/tags.html.md
@@ -565,7 +565,7 @@ function myFunc(param){...}
 function myFunc(param){...}
 
 /**
- * @param {!number} param - this is not nullable param.
+ * @param {!Object} param - this is not nullable param.
  */
 function myFunc(param){...}
 


### PR DESCRIPTION
`!number` is equivalent to `number`, so I think it is not a good example.
Instead use `!Object`.

> Functions and all value types (boolean, number, and string) are
> non-nullable by default whether or not they are declared with the
> Non-nullable operator. To make a value or function type nullable, use
> the Nullable operator.
> https://developers.google.com/closure/compiler/docs/js-for-compiler#types