### PR TITLE
Fix error on string repository property in package.json

### DIFF
--- a/src/Publisher/Builder/DocBuilder.js
+++ b/src/Publisher/Builder/DocBuilder.js
@@ -140,7 +140,7 @@ export default class DocBuilder {
       //desc: config.description || packageObj.description,
       version: config.version || packageObj.version,
       //url: config.url || packageObj.repository ? packageObj.repository.url : ''
-      url: packageObj.repository ? packageObj.repository.url : ''
+      url: packageObj.repository && typeof packageObj.repository === 'object' ? packageObj.repository.url : ''
     };
 
     if (indexInfo.url.indexOf('git@github.com:') === 0) {


### PR DESCRIPTION
String is used as shortcut syntax as we use like `npm install user/repo`.
See https://docs.npmjs.com/files/package.json#repository for more details.

## How to reproduce error
```diff
diff --git a/test/fixture/package.json b/test/fixture/package.json
index c02f8fa..1b42a19 100644
--- a/test/fixture/package.json
+++ b/test/fixture/package.json
@@ -1,9 +1,6 @@
 {
   "name": "esdoc-test-fixture",
   "version": "1.2.3",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/h13i32maru/esdoc"
-  },
+  "repository": "h13i32maru/esdoc",
   "main": "./out/src/MyClass.js"
 }
```

```
$ npm run test

> esdoc@0.1.4 test /Users/r7kamura/src/github.com/h13i32maru/esdoc
> node ./script/test.js

error: could not parse /Users/r7kamura/src/github.com/h13i32maru/esdoc/test/fixture/src/UnknownSyntax.js
badge.svg
/Users/r7kamura/src/github.com/h13i32maru/esdoc/src/Publisher/Builder/DocBuilder.js:230
      if (indexInfo.url.indexOf('git@github.com:') === 0) {
                       ^
TypeError: Cannot read property 'indexOf' of undefined
    at IdentifiersDocBuilder._getInfo (/Users/r7kamura/src/github.com/h13i32maru/esdoc/src/Publisher/Builder/DocBuilder.js:147:22)
```